### PR TITLE
Debian Wheezy versions only have two numbers

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,9 +4,9 @@ driver_config:
   require_chef_omnibus: true
 
 platforms:
-- name: debian-7.0
+- name: debian-7
   driver_config:
-    box: debian-7.0
+    box: debian-7
     box_url: https://reaktor-vm.s3.amazonaws.com/vagrant/debian-7.0.0_chef-11.4.4.box
 - name: debian-6.0
   driver_config:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.5.3 / _Unreleased_
 
+- Fix Wheezy version number detection ([GH-10])
+    * Point-releases only have two numbers, latest is 7.1
 - Fix tests on Chef 10
     * Lock down apt cookbook
 
@@ -74,3 +76,4 @@
 [GH-6]:  https://github.com/reaktor/chef-debian/issues/6  "Issue 6"
 [GH-7]:  https://github.com/reaktor/chef-debian/issues/7  "Issue 7"
 [GH-8]:  https://github.com/reaktor/chef-debian/issues/8  "Issue 8"
+[GH-10]: https://github.com/reaktor/chef-debian/issues/10 "Issue 10"

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -30,8 +30,8 @@ class Chef
 
       def self.codename_for_platform_version(version)
         case version
-        when /^6\.0/ then "squeeze"
-        when /^7\.0/ then "wheezy"
+        when /^6\./ then "squeeze"
+        when /^7\./ then "wheezy"
         else "stable"
         end
       end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -48,7 +48,7 @@ describe 'debian::default' do
         let(:chef_run) do
           ChefSpec::ChefRunner.new(platform: 'debian', version: '7.0') do |node|
             node.automatic_attrs['lsb'] = {}
-            node.automatic_attrs['platform_version'] = '7.0.1'
+            node.automatic_attrs['platform_version'] = '7.1'
           end.converge 'debian::default'
         end
 

--- a/test/integration/default/bats/test_helper.bash
+++ b/test/integration/default/bats/test_helper.bash
@@ -4,9 +4,9 @@ codename() {
         lsb_release -s -c
     else
         case "$(< /etc/debian_version)" in
-            6.0*) echo 'squeeze';;
-            7.0*) echo 'wheezy';;
-            *)    echo '???';;
+            6.*) echo 'squeeze';;
+            7.*) echo 'wheezy';;
+            *)   echo '???';;
         esac
     fi
 }


### PR DESCRIPTION
The first point-release of Wheezy is 7.1 and not 7.0.1 as before.

`Chef::Debian::Helpers.codename_for_platform_version` and tests have to be modified accordingly.
