### PR TITLE
Fixed bug where execute[apt-get update] was called instead of execute[ap...

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,7 @@ template '/etc/apt/sources.list' do
   owner    'root'
   group    'root'
   mode     00644
-  notifies :run, 'execute[apt-get update]', :immediately
+  notifies :run, 'execute[apt-get-update]', :immediately
 end
 
 include_recipe 'apt'


### PR DESCRIPTION
...t-get-update]

Fixed the following error:
`==> default: [2014-08-13T09:53:28+00:00] ERROR: resource template[/etc/apt/sources.list] is configured to notify resource execute[apt-get update] with action run, but execute[apt-get update] cannot be found in the resource collection. template[/etc/apt/sources.list] is defined in /tmp/vagrant-chef-3/chef-solo-1/cookbooks/debian/recipes/default.rb:27:in `from_file'`

Reproducable by running rspec
