### PR TITLE
Change default mirror to "httpredir.debian.org"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 1.7.3 / _Not released yet_
 
+Breaking changes:
+
+- Default mirror changed to "[httpredir.debian.org](http://httpredir.debian.org/)". This is the official successor of "http.debian.net" and should just work without changes. Thus no major version bump. ([GH-17][])
+
 Improvements:
 
 - Fix compatibility with apt cookbook 2.7.0 and newer using `glob` for `apt_preference`. Requires apt cookbook 1.9.0 or later. ([GH-16][])
@@ -125,3 +129,4 @@ Features:
 [GH-14]: https://github.com/reaktor/chef-debian/issues/14 "Issue 14"
 [GH-15]: https://github.com/reaktor/chef-debian/issues/15 "Issue 15"
 [GH-16]: https://github.com/reaktor/chef-debian/issues/16 "Issue 16"
+[GH-17]: https://github.com/reaktor/chef-debian/issues/17 "Issue 17"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Attributes
 
 Attribute                      | Description                    | Default
 -------------------------------|--------------------------------|----------
-`node['debian']['mirror']`     | Default Debian mirror URI      | `"http://http.debian.net/debian"`
+`node['debian']['mirror']`     | Default Debian mirror URI      | `"http://httpredir.debian.org/debian"`
 `node['debian']['backports_mirror']` | Mirror URI for backports repository | `node['debian']['mirror']` (on Squeeze derived from it)
 `node['debian']['security_mirror']` | Mirror URI for security repository | "http://security.debian.org/debian-security"
 `node['debian']['components']` | Default repository components  | `["main", "contrib", "non-free"]`
@@ -135,7 +135,7 @@ setting `node['debian']['<repo>']` attributes to true or false. By default
 a standard set is included. The other option is to add the wanted repositories
 (e.g. `recipe[debian::backports]`) directly to the run list.
 
-The default base URI (http.debian.net) should be fine for most cases as it
+The default base URI (httpredir.debian.org) should be fine for most cases as it
 redirects to a geographically closest mirror. You can also to set it explicitly
 for example in a role:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@
 #
 # Author:: Teemu Matilainen <teemu.matilainen@reaktor.fi>
 #
-# Copyright 2012-2014, Reaktor Innovations Oy
+# Copyright 2012-2015, Reaktor Innovations Oy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-default['debian']['mirror']                  = 'http://http.debian.net/debian'
+default['debian']['mirror']                  = 'http://httpredir.debian.org/debian'
 default['debian']['backports_mirror']        = nil
 default['debian']['security_mirror']         = nil
 default['debian']['components']              = %w[main contrib non-free]

--- a/spec/recipes/backports_spec.rb
+++ b/spec/recipes/backports_spec.rb
@@ -7,7 +7,7 @@ describe 'debian::backports' do
         debian_runner('6.0.5').converge('debian::backports')
       end
 
-      it { should add_backports_source('http://http.debian.net/debian-backports') }
+      it { should add_backports_source('http://httpredir.debian.org/debian-backports') }
     end
 
     context 'with specified default mirror' do
@@ -56,7 +56,7 @@ describe 'debian::backports' do
         debian_runner('7.0').converge('debian::backports')
       end
 
-      it { should add_backports_source('http://http.debian.net/debian') }
+      it { should add_backports_source('http://httpredir.debian.org/debian') }
     end
 
     context 'with specified default mirror' do

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -9,7 +9,7 @@ describe 'debian::default' do
     end
 
     it { should include_recipe('apt') }
-    it { should add_apt_source('deb http://http.debian.net/debian cheese main contrib non-free') }
+    it { should add_apt_source('deb http://httpredir.debian.org/debian cheese main contrib non-free') }
     it { should include_recipe('debian::security') }
     it { should_not include_recipe('debian::testing') }
 
@@ -23,7 +23,7 @@ describe 'debian::default' do
         end
 
         it do
-          should add_apt_source('deb http://http.debian.net/debian wheezy main contrib non-free')
+          should add_apt_source('deb http://httpredir.debian.org/debian wheezy main contrib non-free')
         end
       end
 
@@ -36,7 +36,7 @@ describe 'debian::default' do
         end
 
         it do
-          should add_apt_source('deb http://http.debian.net/debian wheezy main contrib non-free')
+          should add_apt_source('deb http://httpredir.debian.org/debian wheezy main contrib non-free')
         end
       end
     end

--- a/spec/recipes/stable_lts_spec.rb
+++ b/spec/recipes/stable_lts_spec.rb
@@ -8,7 +8,7 @@ describe 'debian::stable_lts' do
 
     it 'configures the LTS repository' do
       expect(chef_run).to add_apt_source(
-        'deb http://http.debian.net/debian squeeze-lts main contrib non-free',
+        'deb http://httpredir.debian.org/debian squeeze-lts main contrib non-free',
         'stable-lts.list')
     end
   end

--- a/test/integration/default/bats/sources.bats
+++ b/test/integration/default/bats/sources.bats
@@ -3,7 +3,7 @@
 load test_helper
 
 @test "sources.list is configured" {
-    local mirror='http://http.debian.net/debian'
+    local mirror='http://httpredir.debian.org/debian'
     grep -qE "^deb\s+$(regexp_escape $mirror) $(codename) main contrib non-free$" /etc/apt/sources.list
 }
 


### PR DESCRIPTION
"[httpredir.debian.org](http://httpredir.debian.org/)" is the official successor of "http.debian.net" and should just work without changes.