### PR TITLE
Allow using backports-sloppy repository on wheezy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Breaking changes:
 
 - Default mirror changed to "[httpredir.debian.org](http://httpredir.debian.org/)". This is the official successor of "http.debian.net" and should just work without changes. Thus no major version bump. ([GH-17][])
 
+Features:
+
+- Allow using backports-sloppy repository on Debian 7.0 wheezy. ([GH-18][])
+
 Improvements:
 
 - Fix compatibility with apt cookbook 2.7.0 and newer using `glob` for `apt_preference`. Requires apt cookbook 1.9.0 or later. ([GH-16][])
@@ -130,3 +134,4 @@ Features:
 [GH-15]: https://github.com/reaktor/chef-debian/issues/15 "Issue 15"
 [GH-16]: https://github.com/reaktor/chef-debian/issues/16 "Issue 16"
 [GH-17]: https://github.com/reaktor/chef-debian/issues/17 "Issue 17"
+[GH-18]: https://github.com/reaktor/chef-debian/issues/18 "Issue 18"

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The other recipes configure apt to use the corresponding Debian repository:
   * `backports` - Sets up apt source for [Debian Backports]
     (http://wiki.debian.org/Backports) repository.
   * `backports_sloppy` - Sets up apt source for [Debian Backports/sloppy]
-    (http://backports.debian.org/Instructions/#index4h2) repository. Only
-    supported on Squeeze. Also includes the `backports` recipe.
+    (http://backports.debian.org/Instructions/#index4h2) repository. Currently
+    supported upto wheezy. Also includes the `backports` recipe.
   * `security` - Sets up apt source for [Debian Security Updates]
     (http://www.debian.org/security/) repository.
   * `sid` - Alias for `unstable` recipe.

--- a/recipes/backports_sloppy.rb
+++ b/recipes/backports_sloppy.rb
@@ -4,7 +4,7 @@
 #
 # Author:: Teemu Matilainen <teemu.matilainen@reaktor.fi>
 #
-# Copyright 2013-2014, Reaktor Innovations Oy
+# Copyright 2013-2015, Reaktor Innovations Oy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-if node['platform_version'].to_i >= 7
+if node['platform_version'].to_i >= 8
   Chef::Log.warn "#{node['debian']['codename']}-backports-sloppy does not exist yet"
   Chef::Log.warn "Please file an issue if I'm wrong: https://github.com/reaktor/chef-debian/issues"
   Chef::Log.info 'Including `debian::backports` recipe instead'

--- a/spec/recipes/backborts_sloppy_spec.rb
+++ b/spec/recipes/backborts_sloppy_spec.rb
@@ -20,9 +20,21 @@ describe 'debian::backports_sloppy' do
       debian_runner('7.0').converge('debian::backports_sloppy')
     end
 
+    it 'configures debian-backports-sloppy repository' do
+      expect(chef_run).to add_apt_source(
+        'deb http://httpredir.debian.org/debian wheezy-backports-sloppy main contrib non-free',
+        'backports-sloppy.list')
+    end
+  end
+
+  context 'on Jessie' do
+    let(:chef_run) do
+      debian_runner('8.0').converge('debian::backports_sloppy')
+    end
+
     it 'warns' do
       allow(Chef::Log).to receive(:warn)
-      expect(Chef::Log).to receive(:warn).with('wheezy-backports-sloppy does not exist yet')
+      expect(Chef::Log).to receive(:warn).with('jessie-backports-sloppy does not exist yet')
       chef_run
     end
     it 'includes debian::backports recipe' do


### PR DESCRIPTION
Enable use wheezy-backports-sloppy (but not by default).