### PR TITLE
Include `backports` recipe always on `backports_sloppy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Improvements:
 
 - Fix compatibility with apt cookbook 2.7.0 and newer using `glob` for `apt_preference`. Requires apt cookbook 1.9.0 or later. ([GH-16][])
 
+Bug fixes:
+
+- `backports_sloppy` should always include the `backports` recipe. ([GH-19][])
+
 # 1.7.2 / 2014-08-22
 
 Improvements:
@@ -135,3 +139,4 @@ Features:
 [GH-16]: https://github.com/reaktor/chef-debian/issues/16 "Issue 16"
 [GH-17]: https://github.com/reaktor/chef-debian/issues/17 "Issue 17"
 [GH-18]: https://github.com/reaktor/chef-debian/issues/18 "Issue 18"
+[GH-19]: https://github.com/reaktor/chef-debian/issues/19 "Issue 19"

--- a/recipes/backports_sloppy.rb
+++ b/recipes/backports_sloppy.rb
@@ -23,10 +23,11 @@ if node['platform_version'].to_i >= 8
   Chef::Log.warn "#{node['debian']['codename']}-backports-sloppy does not exist yet"
   Chef::Log.warn "Please file an issue if I'm wrong: https://github.com/reaktor/chef-debian/issues"
   Chef::Log.info 'Including `debian::backports` recipe instead'
-  include_recipe 'debian::backports'
 else
   debian_repository 'backports-sloppy' do
     uri Chef::Debian::Helpers.backports_mirror(node)
     distribution "#{node['debian']['codename']}-backports-sloppy"
   end
 end
+
+include_recipe 'debian::backports'

--- a/spec/recipes/backborts_sloppy_spec.rb
+++ b/spec/recipes/backborts_sloppy_spec.rb
@@ -8,6 +8,9 @@ describe 'debian::backports_sloppy' do
       end.converge('debian::backports_sloppy')
     end
 
+    it 'includes debian::backports recipe' do
+      expect(chef_run).to include_recipe('debian::backports')
+    end
     it 'configures debian-backports-sloppy repository' do
       expect(chef_run).to add_apt_source(
         'deb http://example.com/debian-backports squeeze-backports-sloppy main contrib non-free',
@@ -20,6 +23,9 @@ describe 'debian::backports_sloppy' do
       debian_runner('7.0').converge('debian::backports_sloppy')
     end
 
+    it 'includes debian::backports recipe' do
+      expect(chef_run).to include_recipe('debian::backports')
+    end
     it 'configures debian-backports-sloppy repository' do
       expect(chef_run).to add_apt_source(
         'deb http://httpredir.debian.org/debian wheezy-backports-sloppy main contrib non-free',


### PR DESCRIPTION
The docs were correct, we should really also include the normal backports repository when using backports_sloppy.