### PR TITLE
Replace stable-backports by jessie-backports

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -32,6 +32,7 @@ class Chef
         case version
         when /^6\./ then 'squeeze'
         when /^7\./ then 'wheezy'
+        when /^8\./ then 'jessie'
         else 'stable'
         end
       end

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -29,7 +29,7 @@ describe Chef::Debian::Helpers do
       '6.0.7'   => 'squeeze',
       '7.0'     => 'wheezy',
       '7.1'     => 'wheezy',
-      '8.0'     => 'stable',
+      '8.0'     => 'jessie',
       'unknown' => 'stable',
     }
     versions.each do |version, codename|


### PR DESCRIPTION
Avoid the following `apt-get` warning:

> ```
> W: Conflicting distribution: http://httpredir.debian.org stable-backports InRelease
> (expected stable-backports but got jessie-backports)
> ```
